### PR TITLE
add Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+os: linux
+
+sudo: false
+
+language: python
+
+install:
+  - pip install hacking autopep8
+
+script:
+  - flake8
+  - autopep8 -r . --diff | tee check_autopep8
+  - test ! -s check_autopep8

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[flake8]
+exclude = ./benchmarks/numpy,cupy,env,html,results,.git
+
+[pep8]
+exclude = ./benchmarks/numpy,cupy,env,html,results,.git


### PR DESCRIPTION
`benchmarks/numpy` is excluded from syntax check as it is a port from NumPy.